### PR TITLE
Update unsafe code to fix new rustc debug safety checks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,7 +410,7 @@ impl<T: Clone> SliceRing<T> for SliceRingImpl<T> {
                 let dst = output.as_mut_ptr().add(i);
                 let src_index = self.wrap_add(self.first_readable, i);
                 let src = (*self.buf.as_ptr().add(src_index)).clone();
-                // NOTE: Drop the dst value as late as possible in case a panic occursin the Clone impl
+                // NOTE: Drop the dst value as late as possible in case a panic occurs in the Clone impl
                 if std::mem::needs_drop::<T>() {
                     std::ptr::drop_in_place(dst);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,12 +175,12 @@ pub struct SliceRingImpl<T> {
     /// index into `buf` of the first element that could be read.
     /// only gets incremented, never decremented.
     /// wraps around.
-    first_readable: usize,
+    pub first_readable: usize,
     /// index into `buf` where the next element could we written.
     /// only gets incremented, never decremented.
     /// wraps around at `buf.cap()`.
-    next_writable: usize,
-    buf: Vec<T>,
+    pub next_writable: usize,
+    pub buf: Vec<T>,
 }
 
 /// Calculate the number of elements left to be read in the buffer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,6 +410,7 @@ impl<T: Clone> SliceRing<T> for SliceRingImpl<T> {
                 let dst = output.as_mut_ptr().add(i);
                 let src_index = self.wrap_add(self.first_readable, i);
                 let src = (*self.buf.as_ptr().add(src_index)).clone();
+                // NOTE: Drop the dst value as late as possible in case a panic occursin the Clone impl
                 if std::mem::needs_drop::<T>() {
                     std::ptr::drop_in_place(dst);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,12 +175,12 @@ pub struct SliceRingImpl<T> {
     /// index into `buf` of the first element that could be read.
     /// only gets incremented, never decremented.
     /// wraps around.
-    pub first_readable: usize,
+    first_readable: usize,
     /// index into `buf` where the next element could we written.
     /// only gets incremented, never decremented.
     /// wraps around at `buf.cap()`.
-    pub next_writable: usize,
-    pub buf: Vec<T>,
+    next_writable: usize,
+    buf: Vec<T>,
 }
 
 /// Calculate the number of elements left to be read in the buffer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,6 +408,9 @@ impl<T: Clone> SliceRing<T> for SliceRingImpl<T> {
             // extra operations during the loop can prevent this optimisation.
             unsafe {
                 let dst = output.get_unchecked_mut(i);
+                if std::mem::needs_drop::<T>() {
+                    std::ptr::drop_in_place(dst);
+                }
                 let src_index = self.wrap_add(self.first_readable, i);
                 let src = (*self.buf.as_ptr().add(src_index)).clone();
                 ptr::write(dst, src);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,12 +407,12 @@ impl<T: Clone> SliceRing<T> for SliceRingImpl<T> {
             // similarly fast) when T is Copy. LLVM is easily confused, so any
             // extra operations during the loop can prevent this optimisation.
             unsafe {
-                let dst = output.get_unchecked_mut(i);
+                let dst = output.as_mut_ptr().add(i);
+                let src_index = self.wrap_add(self.first_readable, i);
+                let src = (*self.buf.as_ptr().add(src_index)).clone();
                 if std::mem::needs_drop::<T>() {
                     std::ptr::drop_in_place(dst);
                 }
-                let src_index = self.wrap_add(self.first_readable, i);
-                let src = (*self.buf.as_ptr().add(src_index)).clone();
                 ptr::write(dst, src);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,7 +382,7 @@ impl<T: Clone> SliceRing<T> for SliceRingImpl<T> {
             // each copy consecutive elements
             unsafe {
                 let dst_index = self.wrap_add(self.next_writable, i);
-                let dst = self.buf.get_unchecked_mut(dst_index);
+                let dst = self.buf.as_mut_ptr().add(dst_index);
                 let src = input.get_unchecked(i).clone();
                 ptr::write(dst, src);
             }
@@ -409,7 +409,7 @@ impl<T: Clone> SliceRing<T> for SliceRingImpl<T> {
             unsafe {
                 let dst = output.get_unchecked_mut(i);
                 let src_index = self.wrap_add(self.first_readable, i);
-                let src = self.buf.get_unchecked(src_index).clone();
+                let src = (*self.buf.as_ptr().add(src_index)).clone();
                 ptr::write(dst, src);
             }
         }


### PR DESCRIPTION
The internal ring buffer is using a zero-length `Vec` as a heap-allocated buffer. Due to the usage of `slice::get_unchecked{_mut}` to acquire pointers into the buffer, this crate is now failing at runtime in debug mode due to some safety checks added in newer versions of rustc. This PR updates these usages of unsafe to use raw pointers "all the way down" to avoid creating intermediate references to uninitialized memory.

Additionally, this makes a small change to `read_many_front` to drop items in the output buffer if needed. This is not required for safety, but it is more correct.

Note that the fields of `SliceRingImpl` are all public, which nullifies any invariants relied upon by the unsafe functions. I opted not to make them private in this PR, so that a new semver-compatible version can be published to allow existing dependencies to use this fix without manual updates from their maintainers. Ideally, all other `0.1.x` versions of this crate should be yanked to force cargo to select the new published version -- most crates depending on this one are quite old so it is very unlikely that all relevant maintainers will update their depended version.